### PR TITLE
fix: evaluate array instructions in playground

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -508,21 +508,21 @@
             case '^':
               return this.resolve(tokens[1], locals, args);
             case '[':
-              const size = parseInt(tokens[2]);
+              const size = parseInt(this.resolve(tokens[2], locals, args));
               this.assign(tokens[1], Array(size).fill(0), locals);
               break;
             case ']':
               const arr = this.resolve(tokens[2], locals, args);
               const idx = parseInt(this.resolve(tokens[3], locals, args));
-              this.assign(tokens[1], idx < arr.length ? arr[idx] : 0, locals);
+              const ok = Array.isArray(arr) && Number.isFinite(idx) && idx >= 0 && idx < arr.length;
+              this.assign(tokens[1], ok ? arr[idx] : 0, locals);
               break;
             case '{':
               if (tokens.length >= 4) {
                 const arr = this.resolve(tokens[1], locals, args);
                 const idx = parseInt(this.resolve(tokens[2], locals, args));
-                if (Array.isArray(arr) && idx < arr.length) {
-                  arr[idx] = this.resolve(tokens[3], locals, args);
-                }
+                const ok = Array.isArray(arr) && Number.isFinite(idx) && idx >= 0 && idx < arr.length;
+                if (ok) arr[idx] = this.resolve(tokens[3], locals, args);
               }
           }
           pc++;


### PR DESCRIPTION
# 概要

playgroundモードで配列に関する命令（`[`. `]`, `{`）が動作していなかったため追加しました。

# 変更点

Python版の命令 `[`. `]`, `{` との[実装](https://github.com/TakatoHonda/sui-lang/blob/05f1bdb651fb771ae805b380687fe1a6d9f45af7/sui.py#L282)と同様の実装をPlaygroundのinterpreterに追加しました。

# 動作確認

以下のソースコードの実行結果がPython版、Playgroundで一致することを確認しました。

```
[ v0 1
{ v0 0 100
] v1 v0 0
. v1
```

- Python版の実行結果

```
 $ sui arr.sui
100
```

- Playground版（修正後）の実行結果

<img width="1230" height="374" alt="image" src="https://github.com/user-attachments/assets/7ca2eb2b-4454-4236-abf6-4dc65888b239" />

