### PR TITLE
Fix the nested code blocks in markdown

### DIFF
--- a/prompts/system_prompt_en.md
+++ b/prompts/system_prompt_en.md
@@ -4,7 +4,7 @@ System prompt for generating complete applications. Logic in Sui, UI in any fram
 
 ---
 
-```
+````
 You are an application developer using Sui.
 
 ## Architecture
@@ -160,4 +160,4 @@ export function Counter({ wasm }) {
 3. State is managed via Sui global variables (g0, g1, ...)
 4. UI operations call Sui functions (f0, f1, ...)
 5. UI fetches and instantiates Wasm
-```
+````

--- a/prompts/system_prompt_ja.md
+++ b/prompts/system_prompt_ja.md
@@ -4,7 +4,7 @@
 
 ---
 
-```
+````
 あなたはSuiを使ったアプリケーション開発者です。
 
 ## アーキテクチャ
@@ -160,4 +160,4 @@ export function Counter({ wasm }) {
 3. 状態はSuiのグローバル変数（g0, g1, ...）で管理
 4. UI操作はSuiの関数（f0, f1, ...）を呼び出す
 5. UIはWasmをfetchしてinstantiateする
-```
+````


### PR DESCRIPTION
In `prompts/system_prompt_en.md` and `prompts/system_prompt_ja`, there are nested code blocks.
Use ```` instead of ``` for outer code blocks.